### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/reference_title_citation_update.py
+++ b/reference_title_citation_update.py
@@ -30,7 +30,7 @@ AUTHOR_TYPE = 'Author'
 PMC_URL_TYPE = 'PMC full text'
 DOI_URL_TYPE = 'DOI full text'
 PMC_ROOT = 'http://www.ncbi.nlm.nih.gov/pmc/articles/'
-DOI_ROOT = 'http://dx.doi.org/'
+DOI_ROOT = 'https://doi.org/'
 
 def update_reference_data(log_file):
  

--- a/scripts/loading/load_reference_triage.py
+++ b/scripts/loading/load_reference_triage.py
@@ -91,7 +91,7 @@ def load_references():
                     doi = id.replace(' [doi]', '')
                     break
             if doi:
-                doi_url = "/".join(['http://dx.doi.org', doi])
+                doi_url = "/".join(['https://doi.org', doi])
         title = record.get('TI', '')
         authors = record.get('AU', [])
         pubdate = record.get('DP', '')  # 'PubDate': '2012 Mar 20'  
@@ -109,7 +109,7 @@ def load_references():
         # doi_url = ""
         # if record.get('DOI'):
         #     doi = record.get('DOI')
-        #     doi_url = "/".join(['http://dx.doi.org', doi])
+        #     doi_url = "/".join(['https://doi.org', doi])
         # title = record.get('Title', '')
         # authors = record.get('AuthorList', [])
         # pubdate = record.get('PubDate', '')  # 'PubDate': '2012 Mar 20'  

--- a/scripts/loading/reference/add_reference.py
+++ b/scripts/loading/reference/add_reference.py
@@ -13,7 +13,7 @@ CREATED_BY = os.environ['DEFAULT_USER']
 
 __author___ = 'sweng66'
 
-doi_root = 'http://dx.doi.org/'
+doi_root = 'https://doi.org/'
 pubmed_root = 'http://www.ncbi.nlm.nih.gov/pubmed/'
 pmc_root = 'http://www.ncbi.nlm.nih.gov/pmc/articles/'
 status = 'Published'

--- a/scripts/loading/reference/promote_reference_triage.py
+++ b/scripts/loading/reference/promote_reference_triage.py
@@ -9,7 +9,7 @@ from scripts.loading.database_session import get_session
 
 Entrez.email = "sweng@stanford.edu"
 
-doi_root = 'http://dx.doi.org/'
+doi_root = 'https://doi.org/'
 pubmed_root = 'http://www.ncbi.nlm.nih.gov/pubmed/'
 pmc_root = 'http://www.ncbi.nlm.nih.gov/pmc/articles/'
 status = 'Published'

--- a/scripts/loading/reference/promote_reference_triage_from_file.py
+++ b/scripts/loading/reference/promote_reference_triage_from_file.py
@@ -14,7 +14,7 @@ from database_session import get_nex_session as get_session
 
 Entrez.email = "sweng@stanford.edu"
 
-doi_root = 'http://dx.doi.org/'
+doi_root = 'https://doi.org/'
 pubmed_root = 'http://www.ncbi.nlm.nih.gov/pubmed/'
 pmc_root = 'http://www.ncbi.nlm.nih.gov/pmc/articles/'
 status = 'Published'

--- a/scripts/loading/reference/reference_title_citation_update.py
+++ b/scripts/loading/reference/reference_title_citation_update.py
@@ -31,7 +31,7 @@ AUTHOR_TYPE = 'Author'
 PMC_URL_TYPE = 'PMC full text'
 DOI_URL_TYPE = 'DOI full text'
 PMC_ROOT = 'http://www.ncbi.nlm.nih.gov/pmc/articles/'
-DOI_ROOT = 'http://dx.doi.org/'
+DOI_ROOT = 'https://doi.org/'
 
 def update_reference_data(log_file):
  

--- a/scripts/loading/reference/reference_triage.py
+++ b/scripts/loading/reference/reference_triage.py
@@ -95,7 +95,7 @@ def load_references(log_file):
                     doi = id.replace(' [doi]', '')
                     break
             if doi:
-                doi_url = "/".join(['http://dx.doi.org', doi])
+                doi_url = "/".join(['https://doi.org', doi])
         title = record.get('TI', '')
         authors = record.get('AU', [])
         pubdate = record.get('DP', '')  # 'PubDate': '2012 Mar 20'  

--- a/scripts/loading/reference/reference_update.py
+++ b/scripts/loading/reference/reference_update.py
@@ -35,7 +35,7 @@ AUTHOR_TYPE = 'Author'
 PMC_URL_TYPE = 'PMC full text'
 DOI_URL_TYPE = 'DOI full text'
 PMC_ROOT = 'http://www.ncbi.nlm.nih.gov/pmc/articles/'
-DOI_ROOT = 'http://dx.doi.org/'
+DOI_ROOT = 'https://doi.org/'
 
 field_names = ['citation', 'title', 'year', 'volume', 'issue', 'page', 'doi', 'pmcid',
                'publication_status', 'author_name', 'pub_type', 'abstract', 'pmc_url',

--- a/scripts/loading/reference/reference_url_update.py
+++ b/scripts/loading/reference/reference_url_update.py
@@ -20,7 +20,7 @@ SLEEP_TIME = 2
 PMC_URL_TYPE = 'PMC full text'
 DOI_URL_TYPE = 'DOI full text'
 PMC_ROOT = 'http://www.ncbi.nlm.nih.gov/pmc/articles/'
-DOI_ROOT = 'http://dx.doi.org/'
+DOI_ROOT = 'https://doi.org/'
 SRC = 'NCBI'
 
 def update_all_urls(log_file):

--- a/src/loading/promote_reference_triage.py
+++ b/src/loading/promote_reference_triage.py
@@ -10,7 +10,7 @@ from ..models import DBSession, Dbentity, Referencedbentity, Referencedocument, 
                    Journal, Locusdbentity
 from src.helpers import link_gene_names
 
-doi_root = 'http://dx.doi.org/'
+doi_root = 'https://doi.org/'
 pubmed_root = 'http://www.ncbi.nlm.nih.gov/pubmed/'
 pmc_root = 'http://www.ncbi.nlm.nih.gov/pmc/articles/'
 status = 'Published'


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

Although there is no urgent need to do anything, I'd hereby like to suggest to follow the new recommendation and update all instances of the old resolver URL.

Cheers!