### PR TITLE
Upgrade Flask to v0.12.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cryptography==1.8.1
 enum34==1.1.2
 factory-boy==2.6.0
 fake-factory==0.5.3
-Flask==0.10.1
+Flask==0.12.3
 funcsigs==0.4
 futures==3.0.3
 httplib2==0.9.2


### PR DESCRIPTION
To remove the security vulnerability that Github is reporting in Flask v0.10.1