### PR TITLE
5315-varnish-healthcheck-bypass

### DIFF
--- a/system_config/varnish.vcl
+++ b/system_config/varnish.vcl
@@ -62,7 +62,7 @@ sub vcl_recv {
     }
 
     # don't cache healthcheck
-    if (req.url ~ "healthcheck$") {
+    if (req.url ~ "^/locus/S000005085$") {
         return (pass);
     }
 }


### PR DESCRIPTION
Change healthcheck URL (pass) to AAH1 LSP.

Hotfix change already applied to production.  Just need to merge change into master.