### PR TITLE
update documentation for setup, update Makefile, and travis to align test target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - printf 'export S3_SECRET_KEY="S3 SECRET KEY"\n' >> test_variables.sh
   - printf 'export S3_ACCESS_KEY="S3 ACCESS KEY"\n' >> test_variables.sh
   - printf 'export BOTO_CONFIG=/dev/null\n' >> test_variables.sh
-  - source test_variables.sh && nosetests -s --with-coverage
+  - make NOSEOPTS='--with-coverage' tests
 after_success:
   - coveralls
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: test lib config
 
+SHELL := /bin/bash
+
 build:
 	npm install
 	npm run build
@@ -13,9 +15,13 @@ prod-build:
 run:
 	source dev_variables.sh && pserve development.ini --reload
 
+NOSEOPTS ?=
+
 tests:
+	source test_variables.sh && nosetests -s $(NOSEOPTS)
+
+npm-tests:
 	npm test
-	source test_variables.sh && nosetests -s
 
 qa-index-redis:
 	source dev_variables.sh && NEX2_URI=$$QA_NEX2_URI && cap qa deploy:redis

--- a/README.md
+++ b/README.md
@@ -8,15 +8,36 @@ SGD API documentation can be found at https://github.com/yeastgenome/SGDBackend-
 
 ## Setup
 
-Prerequisites: node.js 6.0.0+ and Python 2.7.x.  To simplify Python setup, virtualenv is highly suggested.
+Prerequisites: node.js 6.0.0+, Python 3 (to simplify Python setup, virtualenv is highly suggested), and redis.
 
 Make sure you have the needed environmental variables configured in dev_variables.sh, then
 
     $ make build
 
+If `npm install` fails with:
+
+    npm ERR! ERESOLVE unable to resolve dependency tree
+
+and your npm install is newer (this happens at least for 7.18.1) then running again with `npm install --legacy-peer-deps` should work.
+
+Lastly, `npm run build` may emit error messages, but everything will continue fine. Ticket for existing errors here: https://redmine.yeastgenome.org/issues/6040
+
+
 ## Run Locally
 
+To run locally you must have a running instance of Redis. On Ubuntu style Linux systems after installing with `apt-get install redis` a redis service should have been started.
+
+This can be turned on and off with `$ service redis start|stop`. Running a redis instance directly is also possible by `$ redis-server` as long as the redis service is stopped first.
+
+Ensure also that dev_variables.sh is present in the Makefile directory.
+
     $ make run
+
+Running locally will start the backend web service which will point to dev databases. In order to access data in the database with some endpoints (like `/annotations` which rely on being logged in) you'll need a user in the databases.
+
+Navigating a browser to http://localhost:6543/ will show the home login screen. If you have a database user you can then log in.
+
+Not all endpoints require credentials, however. As a test to prove you're getting real data, you can go to http://localhost:6543/complex/CPX-863 which should display JSON.
 
 ## Run Tests
 
@@ -24,13 +45,14 @@ Be sure to have a test_variables.sh file to configure test environemntal variabl
 
     $ make tests
 
-This command runs both the JavaScript tests as well as the Python tests.  To run just the JavaScript tests
+This command runs just the Python tests. To run just the JavaScript tests use
 
     $ npm test
 
-Or the python tests
+or
 
-    $ source test_variables.sh && nosetests -s
+    $ make npm-tests
+
 
 ### Varnish Cache and Rebuilding the cache
 


### PR DESCRIPTION
For https://redmine.yeastgenome.org/issues/6036

I updated documentation in README with my experiences getting the backend setup locally. Additionally I edited the Makefile and travis yaml so that running tests can be done all with the makefile target, so if the test invocation changes we can just change it one place.